### PR TITLE
Adding perform(on: _) method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,23 @@ All notable changes to this project will be documented in this file.
 `Each` adheres to [Semantic Versioning](http://semver.org/).
 
 #### 1.x Releases
-- `1.1.x` Releases - [1.1.0](#110)
+- `1.1.x` Releases - [1.1.0](#110) | [1.1.1](#111)
 - `1.0.x` Releases - [1.0.0](#100) | [1.0.1](#101)
+
+## [1.1.1](https://github.com/dalu93/Each/releases/tag/1.1.1)
+Release on 2016-10-31
+
+#### Added
+- [perform(on: _) method for an automatic memory management system](https://github.com/dalu93/Each/pull/9) by [Luca D'Alberti](https://github.com/dalu93)
+
+#### Fixed
+- [isStopped variable is now read-only from the outside](https://github.com/dalu93/Each/commit/47b68658ef11b7642c8e34584ecf6ed328c5ceaa) by [Luca D'Alberti](https://github.com/dalu93) 
 
 ## [1.1.0](https://github.com/dalu93/Each/releases/tag/1.1.0)
 Released on 2016-10-25
 
 #### Fixed
-- [Fixed the internal protection level error when creating a new instance](https://github.com/dalu93/Each/issues/8)
+- [Fixed the internal protection level error when creating a new instance](https://github.com/dalu93/Each/issues/8) by [Luca D'Alberti](https://github.com/dalu93)
 
 #### Improved
 - [Perform closure return type more readable by using enum](https://github.com/dalu93/Each/pull/7) by [Luca D'Alberti](https://github.com/dalu93)

--- a/Each/ViewController.swift
+++ b/Each/ViewController.swift
@@ -9,7 +9,6 @@
 import UIKit
 
 class ViewController: UIViewController {
-    var a = true
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -17,38 +16,13 @@ class ViewController: UIViewController {
         // 2. Define the value mesure (milliseconds, seconds, minutes, hours)
         // 3. Register the perfom closure
         // 4. Return .continue in the closure to continue, otherwise .stop to stop the timer
-//        Each(1).seconds.perform {
-//            print("second passed")
-//            return .continue
-//        }
+        Each(1).seconds.perform {
+            print("second passed")
+            return .continue
+        }
     }
 
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        
-        guard a else { return }
-        a = false
-        self.present(BVC(), animated: true, completion: nil)
-    }
-}
-
-final class BVC: UIViewController {
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        Each(1).seconds.perform(on: self) {
-            print("timer called")
-            return .continue
-        }
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        
-        self.dismiss(animated: true, completion: nil)
     }
 }

--- a/Each/ViewController.swift
+++ b/Each/ViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 class ViewController: UIViewController {
-
+    var a = true
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -17,14 +17,38 @@ class ViewController: UIViewController {
         // 2. Define the value mesure (milliseconds, seconds, minutes, hours)
         // 3. Register the perfom closure
         // 4. Return .continue in the closure to continue, otherwise .stop to stop the timer
-        Each(1).seconds.perform {
-            print("second passed")
-            return .continue
-        }
+//        Each(1).seconds.perform {
+//            print("second passed")
+//            return .continue
+//        }
     }
 
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        guard a else { return }
+        a = false
+        self.present(BVC(), animated: true, completion: nil)
+    }
 }
 
+final class BVC: UIViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        Each(1).seconds.perform(on: self) {
+            print("timer called")
+            return .continue
+        }
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        self.dismiss(animated: true, completion: nil)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -68,7 +68,19 @@ let timer = Each(1).seconds     // Can be .milliseconds, .seconds, .minute, .hou
 ```swift
 timer.perform {
     // Do your operations
-    // This closure has to return a Boolean value
+    // This closure has to return a NextStep value
+    // Return .continue if you want to leave the timer active, otherwise
+    // return .stop to invalidate it
+}
+```
+
+If you want to leave the memory management decision to the `Each` class, you can simply use the `perform(on: _)` method. 
+It requires that the parameter is an `AnyObject` instance.
+
+```swift
+timer.perform(on: self) {
+    // Do your operations
+    // This closure has to return a NextStep value
     // Return .continue if you want to leave the timer active, otherwise
     // return .stop to invalidate it
 }
@@ -95,6 +107,12 @@ could create. In case of them, two workarounds are provided
 
 ### Workaround 1
 
+Use the `perform(on: _)` method as explained in the [usage](#usage) section.
+Please note that using this method, the `timer` isn't immediately deallocated when the `owner` is deallocated.
+It will be deallocated when the `timer` triggers the next time and it will check whether the `owner` instance is still valid or not.
+
+### Workaround 2
+
 In case you don't want to declare a property that holds the `Each` reference, create a normal `Each` timer in your method scope and return `.stop/true` whenever the `owner` instance is `nil`
 
 ```swift
@@ -108,7 +126,7 @@ Each(1).seconds.perform { [weak self] in
 
 90% of closures will call `self` somehow, so this isn't so bad
 
-### Workaround 2
+### Workaround 3
 
 In case the first workaround wasn't enough, you can declare a property that holds the `Each` reference and call the `stop()` function whenever the `owner` is deallocated
 

--- a/Sources/Each.swift
+++ b/Sources/Each.swift
@@ -137,7 +137,7 @@ open class Each {
      */
     public func perform(closure: @escaping PerformClosure) {
         guard _timer == nil else { return }
-        guard let interval = timeInterval else { fatalError("Please, speficy the time unit by using `milliseconds`, `seconds`, `minutes` abd `hours` properties") }
+        guard let interval = timeInterval else { fatalError("Please, speficy the time unit by using `milliseconds`, `seconds`, `minutes` abd `hours` properties.") }
         
         isStopped = false
         _performClosure = closure
@@ -170,7 +170,7 @@ open class Each {
      Restarts the timer
      */
     public func restart() {
-        guard let _performClosure = _performClosure else { fatalError("Don't call the method `start()` in this case. The first time the timer is started automatically") }
+        guard let _performClosure = _performClosure else { fatalError("Don't call the method `start()` without stopping it before.") }
         
         _ = perform(closure: _performClosure)
     }


### PR DESCRIPTION
This method provides an automatic memory leak detection.

By simply using

``` swift
final class BVC: UIViewController {

    override func viewDidLoad() {
        super.viewDidLoad()
        Each(1).seconds.perform(on: self) {
            print("timer called")
            return .continue
        }
    }

    override func viewDidAppear(_ animated: Bool) {
        super.viewDidAppear(animated)

        self.dismiss(animated: true, completion: nil)
    }
}
```

The timer will be released whenever the `owner` will be released.
Actually, the timer is released when it clocks and checks for the owner instance (if it's `nil`): the timer can be still allocated when the `owner` is released, but it will be released as soon as possible when it clocks the next time
